### PR TITLE
Modified Dockerfile to adapt to STLIB dependence

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,16 +1,10 @@
 FROM ubuntu:24.04
 
 # Install git, git-lfs, pip and colorama, and create workspace directory
-RUN curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | bash && \
-    apt-get update && apt-get -y install git git-lfs python3-colorama cmake && \
-    git lfs install && \
-    mkdir -p /workspaces/ST-LIB
-
+RUN apt-get update && apt-get -y install git git-lfs python3-colorama cmake g++ build-essential && \
+    git lfs install
+    
 # Install cubeclt
 RUN mkdir /temp && cd /temp && git clone https://github.com/HyperloopUPV-H8/cubeclt.git && \
     cd cubeclt && git lfs pull && chmod +x cubeclt_1.16.0_installer.sh && \
     echo | LICENSE_ALREADY_ACCEPTED=1 ./cubeclt_1.16.0_installer.sh
-
-# Clone and config ST-LIB
-RUN git clone https://github.com/HyperloopUPV-H8/ST-LIB.git /workspaces/ST-LIB
-ENV STLIB_PATH=/workspaces/ST-LIB


### PR DESCRIPTION
Dockerfile has been modified to build all necessary tools for configure and compile the project and also for not cloning ST-LIB, as now is a submodule