### PR TITLE
[FW-135] Debug in simulator mode

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,7 +1,8 @@
 FROM ubuntu:24.04
 
-# Install git, git-lfs, pip and colorama, and create workspace directory
-RUN apt-get update && apt-get -y install git git-lfs python3-colorama cmake g++ build-essential && \
+# Install git, git-lfs, colorama and build tools
+RUN echo "deb http://security.ubuntu.com/ubuntu focal-security main universe" > /etc/apt/sources.list.d/ubuntu-focal-sources.list && \
+apt-get update && apt-get -y install git git-lfs python3-colorama cmake g++ build-essential libncurses5 libusb-1.0-0 gdb && \
     git lfs install
     
 # Install cubeclt

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,13 +1,19 @@
 {
-	"name" : "Dev Container for Template Project",
-	"build" : {
-		"dockerfile" : "Dockerfile",
-		"options": [ "--platform=linux/amd64" ]
+	"name": "Dev Container for Template Project",
+	"build": {
+		"dockerfile": "Dockerfile",
+		"options": [
+			"--platform=linux/amd64"
+		]
 	},
+	"runArgs": [
+		"--cap-add=SYS_PTRACE",
+		"--security-opt=seccomp=unconfined"
+	],
 	"remoteUser": "root",
-	"customizations" : {
-		"vscode" : {
-			"extensions" : [
+	"customizations": {
+		"vscode": {
+			"extensions": [
 				"ms-vscode.cpptools-extension-pack",
 				"ms-python.python",
 				"mcu-debug.debug-tracker-vscode",

--- a/.gitignore
+++ b/.gitignore
@@ -89,3 +89,6 @@ CMakeUserPresets.json
 *.su
 *.idb
 *.pdb
+
+# Log files
+*.log

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -40,7 +40,27 @@
         "swoFrequency": 2000000,
         "source": "probe",
         "decoders": [{ "type": "console", "label": "ITM", "port": 0 }]
-      }
+      },
+      "stm32cubeprogrammer": "/opt/st/stm32cubeclt_1.16.0/STM32CubeProgrammer/bin"
+    },
+    {
+      "name": "Debug simulator on Rosetta",
+      "type": "cppdbg",
+      "request": "launch",
+      "program": "out/build/latest.elf",
+      "miDebuggerServerAddress": "localhost:1234",
+      "miDebuggerPath": "/usr/bin/gdb",
+      "MIMode": "gdb",
+      "setupCommands": [
+        {
+          "description": "Set architecture to x86-64",
+          "text": "set architecture i386:x86-64",
+          "ignoreFailures": false
+        }
+      ],
+      "preLaunchTask": "Start Debug Server for Simulator on emulated arch",
+      "cwd": "${workspaceFolder}",
+      "externalConsole": false
     }
   ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,12 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+      {
+        "label": "Start Debug Server for Simulator on emulated arch",
+        "type": "shell",
+        "command": "ROSETTA_DEBUGSERVER_PORT=1234 ./out/build/latest.elf",
+        "problemMatcher": [],
+        "isBackground": true
+      }
+    ]
+  }


### PR DESCRIPTION
I have added the ability to debug in simulator mode inside the container.

You surely are seeing strange things in launch.json and task.json files. That's because if you are currently using ARM on a Mac (and that's my case), you surely are using Rosetta to emulate the container architecture, so GDB can't just access your CPU registers. This launch config is made to this specific case, as Rosetta gives you the possibility to debug through it using a GDB server.