### PR TITLE
Add virtual environment

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,7 @@ jobs:
         run: |
           apt install -y python3.12-venv 
           python3 -m venv virtual
-          source bin/activate
+          source virtual/bin/activate
           pip install -r requirements.txt
         shell: bash
       - name: Build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,7 +44,7 @@ jobs:
         shell: bash
       - name: Build
         run: |
-          source bin/activate
+          source virtual/bin/activate
           cmake --preset ${{ inputs.preset }} .
           cmake --build --preset ${{ inputs.preset }}
         shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Configure
         run: |
           apt install -y python3.12-venv 
-          python3 -m venv .
+          python3 -m venv virtual
           source bin/activate
           pip install -r requirements.txt
         shell: bash

--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@
 
 # Python
 __pycache__/
-
+virtual/
 # Build
 Debug/
 Release/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,7 @@ project (template-project ASM C CXX)
 set(EXECUTABLE ${PROJECT_NAME}.elf)
 set(STLIB_DIR ${CMAKE_CURRENT_LIST_DIR}/deps/ST-LIB)
 
+set(VENV_PYTHON "${CMAKE_SOURCE_DIR}/virtual/bin/python")
 
 add_custom_target(
     my_custom_target_that_always_runs ALL
@@ -12,7 +13,7 @@ add_custom_target(
 add_custom_command(
     OUTPUT
         ${CMAKE_CURRENT_BINARY_DIR}/_tmp.h  # fake! ensure we run! 
-    COMMAND python3 ${CMAKE_SOURCE_DIR}/tools/generate_binary_metadata.py
+    COMMAND ${VENV_PYTHON} ${CMAKE_SOURCE_DIR}/tools/generate_binary_metadata.py
 )
 
 option(USE_ETHERNET "Enable ethernet peripheral" OFF)

--- a/README.md
+++ b/README.md
@@ -9,7 +9,11 @@ This makes use of the [ST-LIB](https://github.com/HyperloopUPV-H8/ST-LIB) develo
 ## Container Setup
 To use it you must install [Dev Containers extension on VSCode](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) and [Docker](https://www.docker.com). Be careful to use the instructions related to your OS, as docker not works in the same way exactly between them.
 Then, when you open this folder in VSCode, you will have the ability to reopen it inside the container. Don't worry, the first time you do it takes a loong time.
+## SetUp
+Create a virtual environment with
+>python3 -m venv virtual
 
+at the root of the project
 ## Modes
 ### Simulator
 The container is fully ready to develop, compile and debug the code in simulator mode, so you don't have to worry about setting your environment


### PR DESCRIPTION
Due to the fact that the generation of metadata relies on several python packages, it is recommended to use a virtual environment, but when doing so the CMake script wasnt previously able to find the packages from the venv.

For this purpose:

Create a virtual environment at the root of the project:

`python3 -m venv virtual`
run:
`pip install -r requirements.txt`

and then CMake will take care of the rest.