### PR TITLE
Feat/Devcontainer

### DIFF
--- a/.devcontainer/Containerfile
+++ b/.devcontainer/Containerfile
@@ -1,0 +1,3 @@
+FROM ghcr.io/hyperloop-upv/hyperloop-firmware-toolchain:latest
+
+WORKDIR /workspaces

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,8 +6,7 @@
   "workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",
   "runArgs": [
     "--privileged",
-    "-v", "/dev/bus/usb:/dev/bus/usb",
-    "--userns=keep-id"
+    "-v", "/dev/bus/usb:/dev/bus/usb"
   ],
   "postStartCommand": "stlink-server &",
   "containerEnv": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,28 @@
+{
+  "name": "STM32 Development Lab",
+  "build": {
+    "dockerfile": "Containerfile"
+  },
+  "workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",
+  "runArgs": [
+    "--privileged",
+    "-v", "/dev/bus/usb:/dev/bus/usb",
+    "--userns=keep-id"
+  ],
+  "postStartCommand": "stlink-server &",
+  "containerEnv": {
+    "CONTAINER_NAME": "stm32-project"
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-vscode.cpptools",
+        "marus25.cortex-debug",
+        "twxs.cmake",
+        "ms-vscode.cmake-tools"
+      ]
+    }
+  },
+  "containerUser": "root",
+  "updateRemoteUserUID": true
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -23,5 +23,5 @@
     }
   },
   "containerUser": "root",
-  "updateRemoteUserUID": true
+  "updateRemoteUserUID": false
 }


### PR DESCRIPTION
Just what the title says, use hyperloop-firmware-toolchain image for a devcontainer with usb access to be able to debug from inside the container. Doesn´t really work with the hyperloop-firmware-toolchain image right now, it depends on the new image that would be made from the new ST-LIB dockerfile. It can be tried out by just copying that dockerfile in the .devcontainer/Containerfile here.